### PR TITLE
feat(ConvertMode): Add checking if pandoc is installed

### DIFF
--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -50,7 +50,7 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         """
 
         # Check if pandoc is installed
-        pandoc_cmd = shutil.which('pandco')
+        pandoc_cmd = shutil.which('pandoc')
         if pandoc_cmd is None:
             self._logger.error(
                 'Could not find pandoc. Make sure it is in your path.',

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -10,6 +10,7 @@ Mode responsible for converting markdown files
 import logging
 import os
 import subprocess
+import shutil
 import time
 from typing import TypedDict, Union
 
@@ -47,6 +48,15 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             args {ConvertModeArguments} -- The arguments from the parser
 
         """
+
+        # Check if pandoc is installed
+        pandoc_cmd = shutil.which('pandco')
+        if pandoc_cmd is None:
+            self._logger.error(
+                'Could not find pandoc. Make sure it is in your path.',
+            )
+            raise SystemExit()
+        self._logger.debug(f'Found pandoc @ {pandoc_cmd}')
 
         # Check if args[in_path] is a file or a directory
         if os.path.isdir(os.path.abspath(args['in_path'])):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,7 @@ pycodestyle==2.6.0
 pyparsing==2.4.7
 pytest==6.2.2
 PyYAML==5.4.1
+rope==0.18.0
 six==1.15.0
 termcolor==1.1.0
 toml==0.10.2

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+
 from unittest.mock import Mock, patch
 
 import pytest
@@ -31,6 +33,25 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
     }
     mock_convert_mode.assert_called_once_with(expected_options)
 
+
+@patch('shutil.which')
+def test_convert_mode_checks_pandoc_install(mock_which: Mock):
+    """Check that shutil.which is called to check if pandoc is installed when convert mode is started"""
+    # Test that error is raised when pandoc is not installed
+    mock_which.return_value = None
+    with pytest.raises(SystemExit):
+        main(['convert', 'in', 'out'])
+    # Check that which is aclled
+    mock_which.assert_called_once_with('pandoc')
+    # Set mock value to be a str, meaning pandoc is installed
+    # So no error should be raised
+    mock_which.return_value = '~/bin/pandoc'
+    try:
+        main(['convert', 'in', 'out'])
+    except FileNotFoundError:
+        # FileNotFoundError is expected, since no valid path is given
+        pass
+    mock_which.assert_called_with('pandoc')
 
 # Check that watcher is called with -w (--watch) flag
 # Check that custom watcher is used


### PR DESCRIPTION
feat(ConvertMode): Add checking if pandoc is installed

When convert mode is started a simple check using shutil.which is run to see if pandoc is in the path.

Closes: #10

- chore: Add rope to dev requirements for easy refactoring
- feat: Add check if pandoc is installed (#10)
- fix: fix type in word pandoc
- test: Test checking if pandoc is installed
