### PR TITLE
Add custom pandoc arguments flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,20 @@ optional arguments:
 ### Converting
 Notesystem converts markdown files to html files using pandoc. When given a directory notesystem converts all the files inside the directory. Also all the files in the subdirectories are converted and the directory is copied to the output directory.
 
-```
-usage: notesystem convert [-h] [--watch] in out
+```console
+usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS] in out
 
 positional arguments:
-  in           the file/folder to be converted
-  out          the path to write the converted file(s) to
+  in                  the file/folder to be converted
+  out                 the path to write the converted file(s) to
 
 optional arguments:
-  -h, --help   show this help message and exit
-  --watch, -w  enables watch mode (convert files that have changed as soon as
-               they have changed)
+  -h, --help          show this help message and exit
+  --watch, -w         enables watch mode (convert files that have changed as
+                      soon as they have changed)
+  --pandoc-args ARGS  specify the arguments that need to based on to pandoc.
+                      E.g.: --pandoc-args='--standalone --preserve-tabs'
+
 ```
 
 For example: `notesystem convert notes html_notes` would convert all markdown files inside the folder `notes` to html and save them to the folder `html_notes`

--- a/notes.md
+++ b/notes.md
@@ -8,5 +8,20 @@
 		- Correct flags
 		- Don't test the printing?
 
+# Notes
+
+## Pandoc flags:
+```python
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--pandoc-args")
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+```
+Use: `notesystem convert ... ... --pandoc-args="--flag1 --flag2 --flag3"`
+
 # References;
 - [Command based design pattern](https://refactoring.guru/design-patterns/command) -> Inpsiration for the modes.

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -49,6 +49,7 @@ def create_argparser() -> argparse.ArgumentParser:
     )
     # Set a default, so later on it is clear whith mode is used
     convert_parser.set_defaults(mode='convert')
+
     # Add argumens
     convert_parser.add_argument(
         'in_path',
@@ -69,6 +70,12 @@ def create_argparser() -> argparse.ArgumentParser:
         help='enables watch mode (convert files that have changed as soon as they have changed)',
         action='store_true',
         default=False,
+    )
+
+    convert_parser.add_argument(
+        '--pandoc-args',
+        help="specify the arguments that need to based on to pandoc. E.g.: --pandoc-args='--standalone --preserve-tabs'",
+        metavar='ARGS',
     )
 
     # Check parser
@@ -141,6 +148,7 @@ def main(argv: Optional[Sequence[str]] = None):
                 'in_path': args['in_path'],
                 'out_path': args['out_path'],
                 'watch': args['watch'],
+                'pandoc_args': args['pandoc_args'],
             },
         }
         convert_mode.start(convert_mode_options)

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -89,6 +89,21 @@ def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
     )
 
 
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_args(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags"""
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.html'
+    pd_args = '--preserve-tabs --standalone'
+    pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args}'
+
+    main(['convert', in_file, out_file, f'--pandoc-args="{pd_args}"'])
+
+    run_mock.assert_called_once_with(
+        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
 # @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Github Actions does not play well with tmpdirs')
 # def test_convert_file_converts_file(tmpdir: py.path.local):
 #     """Test that convert file convert the file correctly using pandoc with default GitHub.html5 template"""

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -27,6 +27,7 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': False,
+        'pandoc_args': None,
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -63,6 +64,7 @@ def test_convert_mode_gets_correct_args_with_w_flag(mock_start: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': True,
+        'pandoc_args': None,
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -85,7 +87,8 @@ def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
     # NOTE: No files should be written to test_out/ folder because convert_dir is mocked
     main(['convert', 'tests/test_documents/contains_errors.md', 'test_out.html'])
     convert_file_mock.assert_called_with(
-        'tests/test_documents/contains_errors.md', 'test_out.html',
+        # Note: None is for pandoc_args
+        'tests/test_documents/contains_errors.md', 'test_out.html', None,
     )
 
 
@@ -98,8 +101,7 @@ def test_pandoc_command_with_correct_args(run_mock: Mock):
     pd_args = '--preserve-tabs --standalone'
     pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args}'
 
-    main(['convert', in_file, out_file, f'--pandoc-args="{pd_args}"'])
-
+    main(['convert', in_file, out_file, f'--pandoc-args={pd_args}'])
     run_mock.assert_called_once_with(
         pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
@@ -155,6 +157,7 @@ def test_watcher_is_called_when_watch_mode(start_watch_mode_mock: Mock, _):
         'in_path': 'tests/test_documents/contains_errors.md',
         'out_path': 'test_out.html',
         'watch': True,
+        'pandoc_args': None,
     }
     start_watch_mode_mock.assert_called_once_with(expected_args)
 


### PR DESCRIPTION
In watch mode add `--pandoc-args` flag. This allows to pass extra arguments to pandoc.

Usage: `notesystem convert in.md out.html --pandoc-args='--standalone --preserve-tabs'`

Closes: #12 