### PR TITLE
Add the option to use custom pandoc templates in convertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,22 @@ optional arguments:
 Notesystem converts markdown files to html files using pandoc. When given a directory notesystem converts all the files inside the directory. Also all the files in the subdirectories are converted and the directory is copied to the output directory.
 
 ```
-usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS] in out
+usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS]
+                          [--pandoc-template T]
+                          in out
 
 positional arguments:
-  in                  the file/folder to be converted
-  out                 the path to write the converted file(s) to
+  in                   the file/folder to be converted
+  out                  the path to write the converted file(s) to
 
 optional arguments:
-  -h, --help          show this help message and exit
-  --watch, -w         enables watch mode (convert files that have changed as
-                      soon as they have changed)
-  --pandoc-args ARGS  specify the arguments that need to based on to pandoc.
-                      E.g.: --pandoc-args='--standalone --preserve-tabs'
-
+  -h, --help           show this help message and exit
+  --watch, -w          enables watch mode (convert files that have changed as
+                       soon as they have changed)
+  --pandoc-args ARGS   specify the arguments that need to based on to pandoc.
+                       E.g.: --pandoc-args='--standalone --preserve-tabs'
+  --pandoc-template T  Specify a template for pandoc to use in convertion.
+                       Default: GitHub.html5
 ```
 
 For example: `notesystem convert notes html_notes` would convert all markdown files inside the folder `notes` to html and save them to the folder `html_notes`
@@ -66,6 +69,14 @@ Pandoc has a lot of optional arguments that can be used to customize the documen
 For example: `notesystem convert notes html_notes --pandoc-args='--standalone --perserver-tabs'`
 
 Make sure however to *not* use the following arguments: `-o`, `--from`, `--to`, `--template` (for now), `--mathjax`
+
+### Pandoc templates
+Pandoc allows you to use custom templates. Notesystem uses the `GitHub.html5` template by default (see installation). However you can change what template you want to use using the `--pandoc-template` flag.
+
+For example: `notesystem convert notes html_notes --pandoc-template=my_template.html`
+
+Make sure that the template you want to use is installed in `~/.pandoc/templates` or wherever your pandoc looks for templates.
+
 
 ## Installation
 _Because notesystem still is in development there is no prebuild package available yet._

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -242,12 +242,15 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         """
 
         # Create the pandoc command
-        # TODO: Check if pandoc is installed
-        pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax'
+        template = 'GitHub.html5'  # Default template
+        if self.pandoc_options['template'] is not None:
+            template = self.pandoc_options['template']
 
+        arguments = ''  # No arguments by default
         if self.pandoc_options['arguments'] is not None:
-            # Note: The extra space is needed to add the arguments. Otherwise for example: ... --mathjax--pandoc-argument1
-            pd_command += f' {self.pandoc_options["arguments"]}'
+            arguments = self.pandoc_options['arguments']
+
+        pd_command = f'pandoc {in_file} -o {out_file} --template {template} --mathjax {arguments}'
 
         self._logger.debug(f'Attempting convertion with command: {pd_command}')
         try:

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -26,6 +26,13 @@ from notesystem.modes.base_mode import BaseMode
 from notesystem.common.utils import find_all_md_files
 
 
+class PandocOptions(TypedDict):
+    # Command line arguments to be passed to pandoc
+    arguments: Optional[str]
+    # The template to be used
+    template: Optional[str]
+
+
 class ConvertModeArguments(TypedDict):
     # The input path
     in_path: str
@@ -34,7 +41,7 @@ class ConvertModeArguments(TypedDict):
     # Wether watch mode is enabled
     watch: bool
     # The string of arguments needed to be passed trough to pandoc
-    pandoc_args: Optional[str]
+    pandoc_options: PandocOptions
 
 
 class ConvertMode(BaseMode[ConvertModeArguments]):
@@ -60,6 +67,9 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             raise SystemExit()
         self._logger.debug(f'Found pandoc @ {pandoc_cmd}')
 
+        # Set pandoc options
+        self.pandoc_options: PandocOptions = args['pandoc_options']
+
         # Check if args[in_path] is a file or a directory
         if os.path.isdir(os.path.abspath(args['in_path'])):
             self._convert_dir(args['in_path'], args['out_path'])
@@ -72,7 +82,7 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
                     ),
                 )
             self._convert_file(
-                args['in_path'], args['out_path'], args['pandoc_args'],
+                args['in_path'], args['out_path'],
             )
         else:
             raise FileNotFoundError
@@ -211,7 +221,7 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         else:
             self._logger.info(f"Stoped watching {args['in_path']}")
 
-    def _convert_file(self, in_file: str, out_file, pandoc_args: Optional[str] = None) -> None:
+    def _convert_file(self, in_file: str, out_file) -> None:
         """Convert a markdown file to html
 
         Using pandoc the in_file is converted to a html file which is saved at
@@ -226,7 +236,6 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
                              converted
             out_file {str} -- The absolute path to where the convted file
                               should be saved
-            pandoc_args {Optional[str]} -- The arguments that need to be passed through to pandoc
 
         Returns:
             None
@@ -236,9 +245,9 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         # TODO: Check if pandoc is installed
         pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax'
 
-        if pandoc_args is not None:
+        if self.pandoc_options['arguments'] is not None:
             # Note: The extra space is needed to add the arguments. Otherwise for example: ... --mathjax--pandoc-argument1
-            pd_command += f' {pandoc_args}'
+            pd_command += f' {self.pandoc_options["arguments"]}'
 
         self._logger.debug(f'Attempting convertion with command: {pd_command}')
         try:
@@ -252,7 +261,7 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             self._logger.debug(se)
             raise SystemExit
 
-    def _convert_dir(self, in_dir_path: str, out_dir_path: str, pandoc_args: Optional[str] = None) -> None:
+    def _convert_dir(self, in_dir_path: str, out_dir_path: str) -> None:
         """Converts all the markdown files in a directory (and subdirectory) to html
 
         Using pandoc all the files in the `in_dir_path` directory (and it's subdirectories)
@@ -264,7 +273,6 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         Arguments:
             in_dir_path {str} -- The directory where all the files that need to be converted are located
             out_dir_path {str} -- The directory where all the converted files will be saved.
-            pandoc_args {Optional[str]} -- The arguments that need to be passed through to pandoc. Default: None
 
         Returns:
             None
@@ -358,7 +366,7 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             out_file_path = os.path.join(cur_path, out_filename)
 
             self._logger.info(f'Converted {in_filename} -> {out_filename}')
-            self._convert_file(file_path, out_file_path, pandoc_args)
+            self._convert_file(file_path, out_file_path)
 
         # Remove the TqdmLogger after the progress bare is done
         # if self._visual:

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -6,7 +6,7 @@ from typing import Optional, Sequence
 from termcolor import colored
 
 from notesystem.modes.base_mode import ModeOptions
-from notesystem.modes.convert_mode import ConvertMode, ConvertModeArguments
+from notesystem.modes.convert_mode import ConvertMode, ConvertModeArguments, PandocOptions
 from notesystem.modes.check_mode.check_mode import CheckMode
 
 
@@ -142,13 +142,17 @@ def main(argv: Optional[Sequence[str]] = None):
         }
         check_mode.start(mode_options)
     elif args['mode'] == 'convert':
+        pandoc_options: PandocOptions = {
+            'arguments': args['pandoc_args'],
+            'template': None,
+        }
         convert_mode_options: ModeOptions = {
             'visual': True,
             'args': {
                 'in_path': args['in_path'],
                 'out_path': args['out_path'],
                 'watch': args['watch'],
-                'pandoc_args': args['pandoc_args'],
+                'pandoc_options': pandoc_options,
             },
         }
         convert_mode.start(convert_mode_options)

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -78,6 +78,12 @@ def create_argparser() -> argparse.ArgumentParser:
         metavar='ARGS',
     )
 
+    convert_parser.add_argument(
+        '--pandoc-template',
+        help='Specify a template for pandoc to use in convertion. Default: GitHub.html5',
+        metavar='T',
+    )
+
     # Check parser
     # Used for the checking mode
     check_parser = mode_parser.add_parser(
@@ -144,7 +150,7 @@ def main(argv: Optional[Sequence[str]] = None):
     elif args['mode'] == 'convert':
         pandoc_options: PandocOptions = {
             'arguments': args['pandoc_args'],
-            'template': None,
+            'template': args['pandoc_template'],
         }
         convert_mode_options: ModeOptions = {
             'visual': True,

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -113,7 +113,7 @@ def test_pandoc_command_with_correct_args_options(run_mock: Mock):
 
 
 @patch('subprocess.run')
-def test_pandoc_command_with_correct_args_tempalte(run_mock: Mock):
+def test_pandoc_command_with_correct_args_template(run_mock: Mock):
     """Test that pandoc is called with the correct filenames and flags"""
 
     in_file = 'tests/test_documents/ast_error_test_1.md'

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -127,6 +127,25 @@ def test_pandoc_command_with_correct_args_template(run_mock: Mock):
     )
 
 
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags when a custom template is used and extra arguments are given"""
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.html'
+    pd_template = 'easy_template.html'
+    pd_args = '--preserve-tabs --standalone'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args}'
+
+    main([
+        'convert', in_file, out_file,
+        f'--pandoc-template={pd_template}', f'--pandoc-args={pd_args}',
+    ])
+    run_mock.assert_called_once_with(
+        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
 # @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Github Actions does not play well with tmpdirs')
 # def test_convert_file_converts_file(tmpdir: py.path.local):
 #     """Test that convert file convert the file correctly using pandoc with default GitHub.html5 template"""

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -27,7 +27,10 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': False,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -64,7 +67,10 @@ def test_convert_mode_gets_correct_args_with_w_flag(mock_start: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': True,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -87,8 +93,7 @@ def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
     # NOTE: No files should be written to test_out/ folder because convert_dir is mocked
     main(['convert', 'tests/test_documents/contains_errors.md', 'test_out.html'])
     convert_file_mock.assert_called_with(
-        # Note: None is for pandoc_args
-        'tests/test_documents/contains_errors.md', 'test_out.html', None,
+        'tests/test_documents/contains_errors.md', 'test_out.html',
     )
 
 
@@ -157,7 +162,10 @@ def test_watcher_is_called_when_watch_mode(start_watch_mode_mock: Mock, _):
         'in_path': 'tests/test_documents/contains_errors.md',
         'out_path': 'test_out.html',
         'watch': True,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     start_watch_mode_mock.assert_called_once_with(expected_args)
 

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -98,7 +98,7 @@ def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
 
 
 @patch('subprocess.run')
-def test_pandoc_command_with_correct_args(run_mock: Mock):
+def test_pandoc_command_with_correct_args_options(run_mock: Mock):
     """Test that pandoc is called with the correct filenames and flags"""
 
     in_file = 'tests/test_documents/ast_error_test_1.md'
@@ -110,6 +110,22 @@ def test_pandoc_command_with_correct_args(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
+
+
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_args_tempalte(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags"""
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.html'
+    pd_template = 'easy_template.html'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax '
+
+    main(['convert', in_file, out_file, f'--pandoc-template={pd_template}'])
+    run_mock.assert_called_once_with(
+        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
 
 # @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Github Actions does not play well with tmpdirs')
 # def test_convert_file_converts_file(tmpdir: py.path.local):


### PR DESCRIPTION
Using the `--pandoc-template` flag custom templates can now be passed on the `_convert_file` functions and to pandoc.

Also the way pandoc settings/options are handled in convert mode has changed to allow for options to be added more easily.

Closes: #19 