### PR TITLE
fix(CheckMode): Print a error message instead of raising the error

### DIFF
--- a/notesystem/modes/check_mode/check_mode.py
+++ b/notesystem/modes/check_mode/check_mode.py
@@ -2,6 +2,8 @@ import os
 from typing import List
 from typing import TypedDict
 
+from termcolor import colored
+
 from notesystem.common.utils import find_all_md_files
 from notesystem.common.visual import print_doc_error
 from notesystem.modes.base_mode import BaseMode
@@ -206,7 +208,7 @@ class CheckMode(BaseMode):
         with open(file_path, 'w') as out_file:
             out_file.writelines(correct_lines)
 
-    def _run(self, args) -> None:
+    def _run(self, args: CheckModeArgs) -> None:
         """The internal entry point for CheckMode
 
         Checks if the given in_path is a directory or file and
@@ -229,8 +231,20 @@ class CheckMode(BaseMode):
             )
             errors.append(doc_err)
         else:
-            # TODO: Throw a nice error here
-            raise FileNotFoundError
+            warning_msg = (
+                'Could not find file or directory: ',
+                os.path.abspath(args['in_path']),
+                '\nPlease provide a valid file or directory.',
+
+            )
+            if self._visual:
+                print(colored(''.join(warning_msg), 'red'))
+            else:
+                self._logger.error(
+                    *warning_msg,
+                )
+
+            raise SystemExit(1)
 
         if args['fix']:
             for error in errors:

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -96,8 +96,8 @@ def test_fix_is_called_when_fix_arg_is_passed(_fix_doc_errors: Mock):
 
 
 def test_check_mode_raises_with_non_existing_dir_or_file():
-    """Test that when a invalid path is given FileNotFoundError is raised"""
-    with pytest.raises(FileNotFoundError):
+    """Test that when a invalid path is given SystemExit is raised"""
+    with pytest.raises(SystemExit):
         main(['check', 'no dir'])
 
 


### PR DESCRIPTION
Because this is a terminal program, it is more useful to display an
error message instead of just raising an error that is not handled
anywhere. See #29.


Fixes: #29