### PR TITLE
feat: Disable errors 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E712, W504

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 
 *.egg-info
 *.pyc
+pyrightconfig.json # Just to point pyright to venv path
 
 # Venv
 .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,32 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-docstring-first
-    -   id: debug-statements
-    -   id: name-tests-test
-    -   id: requirements-txt-fixer
-    -   id: double-quote-string-fixer
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.4
-    hooks:
-    -   id: autopep8
--   repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
-    hooks:
-    -   id: add-trailing-comma
-        args: [--py36-plus]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
-    hooks:
-    -   id: mypy
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.4.0
+  hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: debug-statements
+      - id: name-tests-test
+      - id: requirements-txt-fixer
+      - id: double-quote-string-fixer
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v2.4.0
+  hooks:
+    - id: reorder-python-imports
+- repo: https://github.com/pre-commit/mirrors-autopep8
+  rev: v1.5.6
+  hooks:
+    - id: autopep8
+- repo: https://github.com/asottile/add-trailing-comma
+  rev: v2.1.0
+  hooks:
+  - id: add-trailing-comma
+    args: [--py36-plus]
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.812
+  hooks:
+    - id: mypy
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.0
+  hooks:
+  - id: flake8

--- a/README.md
+++ b/README.md
@@ -37,19 +37,22 @@ optional arguments:
 Notesystem converts markdown files to html files using pandoc. When given a directory notesystem converts all the files inside the directory. Also all the files in the subdirectories are converted and the directory is copied to the output directory.
 
 ```
-usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS] in out
+usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS]
+                          [--pandoc-template T]
+                          in out
 
 positional arguments:
-  in                  the file/folder to be converted
-  out                 the path to write the converted file(s) to
+  in                   the file/folder to be converted
+  out                  the path to write the converted file(s) to
 
 optional arguments:
-  -h, --help          show this help message and exit
-  --watch, -w         enables watch mode (convert files that have changed as
-                      soon as they have changed)
-  --pandoc-args ARGS  specify the arguments that need to based on to pandoc.
-                      E.g.: --pandoc-args='--standalone --preserve-tabs'
-
+  -h, --help           show this help message and exit
+  --watch, -w          enables watch mode (convert files that have changed as
+                       soon as they have changed)
+  --pandoc-args ARGS   specify the arguments that need to based on to pandoc.
+                       E.g.: --pandoc-args='--standalone --preserve-tabs'
+  --pandoc-template T  Specify a template for pandoc to use in convertion.
+                       Default: GitHub.html5
 ```
 
 For example: `notesystem convert notes html_notes` would convert all markdown files inside the folder `notes` to html and save them to the folder `html_notes`
@@ -66,6 +69,14 @@ Pandoc has a lot of optional arguments that can be used to customize the documen
 For example: `notesystem convert notes html_notes --pandoc-args='--standalone --perserver-tabs'`
 
 Make sure however to *not* use the following arguments: `-o`, `--from`, `--to`, `--template` (for now), `--mathjax`
+
+### Pandoc templates
+Pandoc allows you to use custom templates. Notesystem uses the `GitHub.html5` template by default (see installation). However you can change what template you want to use using the `--pandoc-template` flag.
+
+For example: `notesystem convert notes html_notes --pandoc-template=my_template.html`
+
+Make sure that the template you want to use is installed in `~/.pandoc/templates` or wherever your pandoc looks for templates.
+
 
 ## Installation
 _Because notesystem still is in development there is no prebuild package available yet._

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For example: `notesystem convert notes html_notes --pandoc-args='--standalone --
 
 Make sure however to *not* use the following arguments: `-o`, `--from`, `--to`, `--template` (for now), `--mathjax`
 
-### Pandoc templates
+#### Pandoc templates
 Pandoc allows you to use custom templates. Notesystem uses the `GitHub.html5` template by default (see installation). However you can change what template you want to use using the `--pandoc-template` flag.
 
 For example: `notesystem convert notes html_notes --pandoc-template=my_template.html`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ optional arguments:
 ### Converting
 Notesystem converts markdown files to html files using pandoc. When given a directory notesystem converts all the files inside the directory. Also all the files in the subdirectories are converted and the directory is copied to the output directory.
 
-```console
+```
 usage: notesystem convert [-h] [--watch] [--pandoc-args ARGS] in out
 
 positional arguments:
@@ -60,7 +60,12 @@ Note: before watching is started all files are converted first.
 
 For example: `notesystem convert notes html_notes -w` would firstly convert all files and then watch the directory for changes
 
+#### Pass arguments to pandoc
+Pandoc has a lot of optional arguments that can be used to customize the documents. Using the `--pandoc-args` flag you can pass these arguments.
 
+For example: `notesystem convert notes html_notes --pandoc-args='--standalone --perserver-tabs'`
+
+Make sure however to *not* use the following arguments: `-o`, `--from`, `--to`, `--template` (for now), `--mathjax`
 
 ## Installation
 _Because notesystem still is in development there is no prebuild package available yet._

--- a/notes.md
+++ b/notes.md
@@ -7,7 +7,8 @@
 		- Correct mode
 		- Correct flags
 		- Don't test the printing?
-
+- Simple visual mode
+	- Just show one line of error info in check mode?
 # Notes
 
 ## Pandoc flags:
@@ -30,3 +31,6 @@ Use: `notesystem convert ... ... --pandoc-args="--flag1 --flag2 --flag3"`
 
 - Keep track of all errors in a central way accesible by the argparser
 - All errors have a help_str method to be printed to the help menu?
+- Should disabled errors still create a warning or just totally be skipped?
+	- In the current implementation they are totally ignored
+- Optimization could be to ignore the error before it get's checked?

--- a/notes.md
+++ b/notes.md
@@ -25,3 +25,8 @@ Use: `notesystem convert ... ... --pandoc-args="--flag1 --flag2 --flag3"`
 
 # References;
 - [Command based design pattern](https://refactoring.guru/design-patterns/command) -> Inpsiration for the modes.
+
+## Disable flags
+
+- Keep track of all errors in a central way accesible by the argparser
+- All errors have a help_str method to be printed to the help menu?

--- a/notesystem/__main__.py
+++ b/notesystem/__main__.py
@@ -1,4 +1,3 @@
-
 from notesystem.notesystem import main
 
 

--- a/notesystem/common/utils.py
+++ b/notesystem/common/utils.py
@@ -1,9 +1,9 @@
 """Commonly used utility functions"""
-import os
 import logging
-from typing import List
-import string
+import os
 import re
+import string
+from typing import List
 
 
 def find_all_md_files(path: str) -> List[str]:
@@ -14,8 +14,6 @@ def find_all_md_files(path: str) -> List[str]:
     Arguments:
         path {str} -- The starting path (should be a directory) to search
                       trough for the files
-
-
     Returns:
         List[str] -- The full paths of the found files
 

--- a/notesystem/common/visual.py
+++ b/notesystem/common/visual.py
@@ -3,8 +3,8 @@ import os
 
 from termcolor import colored
 
-from notesystem.modes.check_mode.errors.base_errors import DocumentErrors
 from notesystem.common.utils import clean_str
+from notesystem.modes.check_mode.errors.base_errors import DocumentErrors
 
 
 def print_doc_error(doc_errs: DocumentErrors, err_fixed: bool = False) -> None:
@@ -12,7 +12,7 @@ def print_doc_error(doc_errs: DocumentErrors, err_fixed: bool = False) -> None:
 
     Arguments:
         doc_errs {DocumentErrors} -- The document error to display
-        assume_fixed {bool} -- Wether the errors are fixed (if possible)
+        assume_fixed {bool}       -- Wether the errors are fixed (if possible)
 
     """
     rows, columns = os.popen('stty size', 'r').read().split()
@@ -46,7 +46,7 @@ def print_doc_error(doc_errs: DocumentErrors, err_fixed: bool = False) -> None:
         if error['line_nr'] is not None:
             print(colored(f"    Line nr: {error['line_nr']}", 'blue'))
         else:
-            print(colored(f'    Line nr: -', 'blue'))
+            print(colored('    Line nr: -', 'blue'))
         print(colored(f"    Error type: {error['error_type']}", 'blue'))
         if error['error_type'].is_fixable():
             if err_fixed:
@@ -60,4 +60,7 @@ def print_doc_error(doc_errs: DocumentErrors, err_fixed: bool = False) -> None:
             if err_fixed:
                 print(colored('    Fixed:', 'blue'), colored('No', 'red'))
             else:
-                print(colored('    Auto fixable:', 'blue'), colored('No', 'red'))
+                print(
+                    colored('    Auto fixable:', 'blue'),
+                    colored('No', 'red'),
+                )

--- a/notesystem/modes/base_mode.py
+++ b/notesystem/modes/base_mode.py
@@ -1,4 +1,8 @@
 """Base class for modes"""
+
+# TODO:
+# - Make the ModeOptions more ge
+
 import abc
 import logging
 from typing import Generic, TypeVar, TypedDict, Dict

--- a/notesystem/modes/base_mode.py
+++ b/notesystem/modes/base_mode.py
@@ -1,11 +1,9 @@
 """Base class for modes"""
-
-# TODO:
-# - Make the ModeOptions more ge
-
-import abc
 import logging
-from typing import Generic, TypeVar, TypedDict, Dict
+from typing import Dict
+from typing import Generic
+from typing import TypedDict
+from typing import TypeVar
 
 
 class ModeArguments(TypedDict):

--- a/notesystem/modes/check_mode/check_mode.py
+++ b/notesystem/modes/check_mode/check_mode.py
@@ -2,6 +2,8 @@ import os
 from typing import List
 from typing import TypedDict
 
+from termcolor import colored
+
 from notesystem.common.utils import find_all_md_files
 from notesystem.common.visual import print_doc_error
 from notesystem.modes.base_mode import BaseMode
@@ -213,7 +215,7 @@ class CheckMode(BaseMode):
         with open(file_path, 'w') as out_file:
             out_file.writelines(correct_lines)
 
-    def _run(self, args) -> None:
+    def _run(self, args: CheckModeArgs) -> None:
         """The internal entry point for CheckMode
 
         Checks if the given in_path is a directory or file and
@@ -236,8 +238,20 @@ class CheckMode(BaseMode):
             )
             errors.append(doc_err)
         else:
-            # TODO: Throw a nice error here
-            raise FileNotFoundError
+            warning_msg = (
+                'Could not find file or directory: ',
+                os.path.abspath(args['in_path']),
+                '\nPlease provide a valid file or directory.',
+
+            )
+            if self._visual:
+                print(colored(''.join(warning_msg), 'red'))
+            else:
+                self._logger.error(
+                    *warning_msg,
+                )
+
+            raise SystemExit(1)
 
         if args['fix']:
             for error in errors:

--- a/notesystem/modes/check_mode/check_mode.py
+++ b/notesystem/modes/check_mode/check_mode.py
@@ -19,6 +19,10 @@ from notesystem.common.visual import print_doc_error
 # ----- CHECK MODE ----- #
 ##########################
 
+# ALL ERRORS
+
+ALL_ERRORS = [MathError, TodoError, SeperatorError, ListIndentError]
+
 
 class CheckModeArgs(TypedDict):
     """Arguments for the check mode"""
@@ -26,12 +30,15 @@ class CheckModeArgs(TypedDict):
     in_path: str
     # Wheter the found mistakes should automatticly be fixed
     fix: bool
+    # Disabled errors
+    disabled_errors: List[str]
 
 
 class CheckMode(BaseMode):
     """Check markdown files for errors and fix them if nessesary"""
 
     # The errors that can be found.
+    # TODO: Replace with a more modular way
     possible_line_markdown_errors: List[MarkdownError] = [
         MathError(), TodoError(),
     ]

--- a/notesystem/modes/check_mode/check_mode.py
+++ b/notesystem/modes/check_mode/check_mode.py
@@ -1,19 +1,18 @@
 import os
-import re
-import abc
-from typing import TypedDict, List, Dict, Tuple, Union
-
-import mistune
-from termcolor import colored
-
-from notesystem.modes.base_mode import BaseMode
-
-from notesystem.modes.check_mode.errors.base_errors import ErrorMeta, DocumentErrors
-from notesystem.modes.check_mode.errors.markdown_errors import TodoError, MathError, SeperatorError, MarkdownError
-from notesystem.modes.check_mode.errors.ast_errors import AstError, ListIndentError
+from typing import List
+from typing import TypedDict
 
 from notesystem.common.utils import find_all_md_files
 from notesystem.common.visual import print_doc_error
+from notesystem.modes.base_mode import BaseMode
+from notesystem.modes.check_mode.errors.ast_errors import AstError
+from notesystem.modes.check_mode.errors.ast_errors import ListIndentError
+from notesystem.modes.check_mode.errors.base_errors import DocumentErrors
+from notesystem.modes.check_mode.errors.base_errors import ErrorMeta
+from notesystem.modes.check_mode.errors.markdown_errors import MarkdownError
+from notesystem.modes.check_mode.errors.markdown_errors import MathError
+from notesystem.modes.check_mode.errors.markdown_errors import SeperatorError
+from notesystem.modes.check_mode.errors.markdown_errors import TodoError
 
 ##########################
 # ----- CHECK MODE ----- #
@@ -52,10 +51,12 @@ class CheckMode(BaseMode):
         """Checks all the markdown files in the given directory for errors
 
         Arguments:
-            dir_path {str} -- The path to the directory containing the markdown files to check.
+            dir_path {str} -- The path to the directory containing the
+                              markdown files to check.
 
         Raises:
-            {NotADirectoryError} -- When the given dir_path does not exist, NotADirectoryError is raised.
+            {NotADirectoryError} -- When the given dir_path does not exist,
+                                    NotADirectoryError is raised.
 
         Returns:
             List[DocumentError] -- The found document errors
@@ -64,7 +65,8 @@ class CheckMode(BaseMode):
 
         if not os.path.isdir(os.path.abspath(dir_path)):
             self._logger.error(
-                f'Could not find directory: {os.path.abspath(dir_path)}. Please provide a valid directory.',
+                f'Could not find directory: {os.path.abspath(dir_path)}. \
+                Please provide a valid directory.',
             )
             raise NotADirectoryError
 
@@ -104,7 +106,8 @@ class CheckMode(BaseMode):
             with open(file_path, 'r') as md_file:
                 lines = md_file.readlines()
         except UnicodeDecodeError as e:
-            # Try different reading mode when UnicodeDecodeError error is thrown
+            # Try different reading mode
+            # when UnicodeDecodeError error is thrown
             self._logger.debug(
                 'Caught UnicodeDecodeError, swithcing read mode',
             )
@@ -116,7 +119,7 @@ class CheckMode(BaseMode):
                 self._logger.warning(
                     f'Could not open {file_path}. Skipping the file...',
                 )
-                self._logger.info(e)
+                self._logger.info(e2)
                 return DocumentErrors(file_path=file_path, errors=errors)
         except Exception as error:
             self._logger.warning(
@@ -134,7 +137,8 @@ class CheckMode(BaseMode):
                     )
                     errors.append(new_err)
 
-            # Go through the errors that need multiple lines to check for errors
+            # Go through the errors that need multiple lines
+            # to check for errors
             for m_err in self.possible_multi_line_markdown_errors:
                 # SeperatorError needs access to multiple lines
                 if isinstance(m_err, SeperatorError):
@@ -151,7 +155,7 @@ class CheckMode(BaseMode):
             if not ast_err.validate(lines):
                 new_err = ErrorMeta(
                     # AstErrors do not need line nummers or line values
-                    # When applying the fix the whole doc will be fixex in one go
+                    # When applying the fix the whole doc will be fixed
                     line_nr=None,
                     line=None,
                     error_type=ast_err,
@@ -216,7 +220,8 @@ class CheckMode(BaseMode):
         conintues accodingly
 
         Arguments:
-            args {CheckModeArgs} -- The arguments as parsed by the parser for the check mode
+            args {CheckModeArgs} -- The arguments as parsed by the parser
+                                    for the check mode
 
         """
         errors: List[DocumentErrors] = []
@@ -231,6 +236,7 @@ class CheckMode(BaseMode):
             )
             errors.append(doc_err)
         else:
+            # TODO: Throw a nice error here
             raise FileNotFoundError
 
         if args['fix']:

--- a/notesystem/modes/check_mode/errors/ast_errors.py
+++ b/notesystem/modes/check_mode/errors/ast_errors.py
@@ -1,6 +1,8 @@
 import enum
-import json
-from typing import List, Dict, TypedDict, Optional, Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import TypedDict
 
 import mistune
 
@@ -35,14 +37,18 @@ class AstNode(TypedDict):
 
 
 class AstError(BaseError):
-    """An error in a markdown file that can be found by checking the the ast of the file"""
+    """
+    An error in a markdown file that can be found by checking
+    the the ast of the file.
+    """
     # Wether the error (type) is fixable
 
     fixable = False
 
     def _create_ast(self, lines: List[str]) -> List[AstNode]:
-        # It is easier to (accuractly) detect a ListIndentError using the ast and reasoning about that
-        # then using a regex that matches any indented list
+        # It is easier to (accuractly) detect a ListIndentError
+        # using the ast and reasoning about that then using a regex
+        # that matches any indented list
         create_ast = mistune.create_markdown(
             escape=False, renderer=mistune.AstRenderer(),
             # TODO: Add plugnis
@@ -53,10 +59,18 @@ class AstError(BaseError):
         return ast
 
     def validate(self, file_lines: List[str]) -> bool:
-        """Validates the AST of the file (checks only for the current error type)"""
+        """Validates the AST of the file
+
+        Arguments:
+            file_lines {List[str]} -- The lines that will be validated
+
+        Returns:
+            {bool} -- Wether the given lines are valid
+
+        """
 
     def fix(self, file_lines: List[str]) -> List[str]:
-        """Fixes the errors of it's type in the lines given and returns the fixed lines """
+        """Fixes the errors of it's type in the given lines"""
 
     def is_fixable(self) -> bool:
         return self.fixable
@@ -76,10 +90,11 @@ class ListIndentError(AstError):
         """Check if there is a ListIndentError present in the given lines
 
         Arguments:
-            file {List[str]} -- The lines of the file to check
+            file_lines {List[str]} -- The lines of the file to validate
 
         Returns:
-            {bool} -- Wether the lines of the file are valid (does not contain a ListIndentError)
+            {bool} -- Wether the lines of the file are valid
+                      (does not contain a ListIndentError)
 
         """
         ast = self._create_ast(file_lines)

--- a/notesystem/modes/check_mode/errors/ast_errors.py
+++ b/notesystem/modes/check_mode/errors/ast_errors.py
@@ -93,5 +93,13 @@ class ListIndentError(AstError):
     def fix(self, file_lines: List[str]) -> List[str]:
         raise Exception('ListIndentError is not fixable')
 
+    @staticmethod
+    def get_help_text() -> str:
+        return 'List Indent Error (list is not properly indented)'
+
+    @staticmethod
+    def get_error_name() -> str:
+        return 'list-indent-error'
+
     def __str__(self):
         return 'List Indent Error (list is not properly indented)'

--- a/notesystem/modes/check_mode/errors/base_errors.py
+++ b/notesystem/modes/check_mode/errors/base_errors.py
@@ -1,6 +1,7 @@
 import abc
-
-from typing import TypedDict, List, Union, Optional
+from typing import List
+from typing import Optional
+from typing import TypedDict
 
 ##########################
 # ----- BASE ERROR ----- #
@@ -17,7 +18,9 @@ class BaseError(abc.ABC):
         """Validates the input lines"""
 
     def fix(self, inp: List[str]) -> List[str]:
-        """Fixes the error given in the inp (input) and returns the corrected lines"""
+        """Fixes the error given in the inp (input) and
+           returns the corrected lines
+        """
 
     def is_fixable(self) -> bool:
         """Returns wether the error is fixable"""
@@ -26,7 +29,7 @@ class BaseError(abc.ABC):
 
     @staticmethod
     def get_help_text() -> str:
-        """Returns the help text to be displayed on the help menu (by argparse)"""
+        """Returns the help text to be displayed on the help menu"""
 
     @staticmethod
     def get_error_name() -> str:

--- a/notesystem/modes/check_mode/errors/base_errors.py
+++ b/notesystem/modes/check_mode/errors/base_errors.py
@@ -22,6 +22,17 @@ class BaseError(abc.ABC):
     def is_fixable(self) -> bool:
         """Returns wether the error is fixable"""
 
+    # Helper functions for the command line
+
+    @staticmethod
+    def get_help_text() -> str:
+        """Returns the help text to be displayed on the help menu (by argparse)"""
+
+    @staticmethod
+    def get_error_name() -> str:
+        """Returns the name of the error to the commandline"""
+
+
 ############################################
 # ----- GENERAL ERROR HANDLING TYPES ----- #
 ############################################

--- a/notesystem/modes/check_mode/errors/markdown_errors.py
+++ b/notesystem/modes/check_mode/errors/markdown_errors.py
@@ -3,14 +3,18 @@ from typing import List
 
 from notesystem.modes.check_mode.errors.base_errors import BaseError
 
-
 ####################################
 # ----- MARKDOWN ERRORS ----- #
 ####################################
 
 # Gernal markdown error
+
+
 class MarkdownError(BaseError):
-    """An error in a markdown file that can be found by checking the markdown syntax line by line"""
+    """
+    An error in a markdown file that can be found by
+    checking the markdown syntax line by line.
+    """
 
     # The pattern the error can be found with
     regex_pattern: str
@@ -18,10 +22,10 @@ class MarkdownError(BaseError):
     fixable = False
 
     def validate(self, line: List[str]) -> bool:
-        """Validates the line (checks if there is an error in the line)"""
+        """Validates the line"""
 
     def fix(self, lines: List[str]) -> List[str]:
-        """Fixes the error on the given line and returns the correct line"""
+        """Fixes the errors of it's type in the given lines"""
 
     def is_fixable(self) -> bool:
         return self.fixable
@@ -36,11 +40,13 @@ class MarkdownError(BaseError):
 
 
 class MathError(MarkdownError):
-    """An error that occurs when math is denoted with $$
+    """An error that occurs when math is denoted with `$$`
 
-    In pandoc markdown math blocks are denoted by $$ and inline is denoted by $.
+    In pandoc markdown math blocks are denoted by `$$`
+    and inline is denoted by `$`.
+
     This is not the case in some other markdown flavors (dropbox paper).
-    So if this fix is applied $$ is changed to $
+    So if this fix is applied `$$` is changed to `$`.
 
     """
     fixable = True
@@ -65,7 +71,7 @@ class MathError(MarkdownError):
         return False
 
     def fix(self, lines: List[str]) -> List[str]:
-        """Fixes the math errors in the current line and returns the correct line
+        """Fixes the math errors in the current line
 
         Arguments:
             line {str} -- The line to fixe
@@ -95,7 +101,8 @@ class MathError(MarkdownError):
 
 
 class SeperatorError(MarkdownError):
-    """An error that is caused when there is no new line after a seperator (---)
+    """
+    An error that is caused when there is no new line after a seperator (---)
 
     In pandoc markdown seperator syntax is:
     ```markdown
@@ -119,7 +126,8 @@ class SeperatorError(MarkdownError):
         """Check if there is a seperator error
 
         Arguments:
-            lines {List[str]} -- The current line and the next line (SeperatorError needs two lines to validate)
+            lines {List[str]} -- The current line and the next line
+                                 (SeperatorError needs two lines to validate)
 
         Returns:
             bool -- Wether the current line (lines[0]) is valid
@@ -217,7 +225,7 @@ class TodoError(MarkdownError):
             raise Exception('TodoError expects one line to fix')
         line = lines[0]
 
-        indent_str = line[:(len(line)-len(line.lstrip()))]
+        indent_str = line[:(len(line) - len(line.lstrip()))]
         correct_line = indent_str + '- ' + line.lstrip()
         return [correct_line]
 

--- a/notesystem/modes/check_mode/errors/markdown_errors.py
+++ b/notesystem/modes/check_mode/errors/markdown_errors.py
@@ -26,6 +26,14 @@ class MarkdownError(BaseError):
     def is_fixable(self) -> bool:
         return self.fixable
 
+    @staticmethod
+    def get_help_text() -> str:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_error_name() -> str:
+        raise NotImplementedError
+
 
 class MathError(MarkdownError):
     """An error that occurs when math is denoted with $$
@@ -73,6 +81,14 @@ class MathError(MarkdownError):
         line = lines[0]
 
         return [line.replace('$$', '$')]
+
+    @staticmethod
+    def get_help_text() -> str:
+        return 'Math Error (`$$` used)'
+
+    @staticmethod
+    def get_error_name() -> str:
+        return 'math-error'
 
     def __str__(self):
         return 'Math Error (`$$` used)'
@@ -137,6 +153,14 @@ class SeperatorError(MarkdownError):
 
         return [line + '\n']
 
+    @staticmethod
+    def get_help_text() -> str:
+        return 'Seperator Error (`---` used without new line)'
+
+    @staticmethod
+    def get_error_name() -> str:
+        return 'seperator-error'
+
     def __str__(self):
         return 'Seperator Error (`---` used without new line)'
 
@@ -196,6 +220,14 @@ class TodoError(MarkdownError):
         indent_str = line[:(len(line)-len(line.lstrip()))]
         correct_line = indent_str + '- ' + line.lstrip()
         return [correct_line]
+
+    @staticmethod
+    def get_help_text() -> str:
+        return 'Todo Error (no `-` used in todo item)'
+
+    @staticmethod
+    def get_error_name() -> str:
+        return 'todo-error'
 
     def __str__(self):
         return 'Todo Error (no `-` used in todo item)'

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -3,10 +3,6 @@ Mode responsible for converting markdown files
 (and directories with markdown files) to html files
 """
 
-# TODO:
-# - Add pandoc template options (should also be added in the arg parser)
-
-
 import logging
 import os
 import subprocess
@@ -248,6 +244,18 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
 
         arguments = ''  # No arguments by default
         if self.pandoc_options['arguments'] is not None:
+            # Check for arguments that should not be passed to pandoc
+            not_allowed_args = [
+                '-o', '--to',
+                '--from', '--template', '--mathjax',
+            ]
+            for not_allowed in not_allowed_args:
+                if not_allowed in self.pandoc_options['arguments']:
+                    self._logger.error(
+                        f'{not_allowed} is allowed as an (extra) pandoc argument.',
+                    )
+                    raise SystemExit(1)
+
             arguments = self.pandoc_options['arguments']
 
         pd_command = f'pandoc {in_file} -o {out_file} --template {template} --mathjax {arguments}'

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -2,24 +2,23 @@
 Mode responsible for converting markdown files
 (and directories with markdown files) to html files
 """
-
-import logging
 import os
-import subprocess
 import shutil
+import subprocess
 import time
-from typing import TypedDict, Union, Optional
+from typing import Optional
+from typing import TypedDict
 
 import tqdm
 from termcolor import colored
+from watchdog.events import FileSystemEvent
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers.polling import PollingObserver as Observer
 from yaspin import yaspin
 from yaspin.spinners import Spinners
 
-from watchdog.observers.polling import PollingObserver as Observer
-from watchdog.events import FileSystemEventHandler, FileSystemEvent
-
-from notesystem.modes.base_mode import BaseMode
 from notesystem.common.utils import find_all_md_files
+from notesystem.modes.base_mode import BaseMode
 
 
 class PandocOptions(TypedDict):
@@ -89,22 +88,28 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             # Start watcher
             self._start_watch_mode(args)
 
-    def _create_watch_handler(self, in_path: str, out_path: str) -> FileSystemEventHandler:
+    def _create_watch_handler(
+        self,
+        in_path: str,
+        out_path: str,
+    ) -> FileSystemEventHandler:
         """Create the handler for the filewatcher
 
         Arguments:
-            in_path {str} -- The input path (file or folder)
-            out_path {str} -- The path the output should be written to (file or folder)
+            in_path {str}  -- The input path (file or folder).
+            out_path {str} -- The path the output should be written to.
 
         Returns:
-            {FileSystemEventHandler} -- The handler that converts created and modified files
+            {FileSystemEventHandler} -- The handler that converts created
+                                        and modified files
 
         """
 
         # Create s special convert function with access to the CheckMode scope.
         def conv(file_path: str):
             if self._visual:
-                print()  # Extra print, otherwise text will show up after the spinner
+                # Extra print, otherwise text will show up after the spinner
+                print()
                 print(
                     colored(
                         'Converting:', 'blue', attrs=[
@@ -156,7 +161,10 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             def on_any_event(self, event: FileSystemEvent):
                 if event.is_directory:
                     return None
-                elif event.event_type == 'created' or event.event_type == 'modified':
+                elif (
+                    event.event_type == 'created' or
+                    event.event_type == 'modified'
+                ):
                     # Only convert markdown files
                     if event.src_path.endswith('.md'):
                         conv(os.path.abspath(event.src_path))
@@ -184,23 +192,27 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
 
         if self._visual:
             print(
-                colored('Starting watcher for:', 'blue', attrs=['bold']), colored(
-                    f"{os.path.abspath(args['in_path'])}", 'blue',
-                ),
+                colored('Starting watcher for:', 'blue', attrs=['bold']),
+                colored(f"{os.path.abspath(args['in_path'])}", 'blue'),
             )
         else:
             self._logger.info(f"Starting watch mode for: {args['in_path']}")
 
         # Start
         observer.start()
-        # Keep the process running while the watcher watches (until KeyboardInterrupt)
+        # Keep the process running while
+        # the watcher watches (until KeyboardInterrupt)
         try:
             while True:
                 # Pretty spinner =)
                 spinner_text = colored(
                     'Watching files', 'blue',
                 ) + colored(' (use Ctrl+c to exit)', 'red')
-                with yaspin(Spinners.bouncingBar, text=spinner_text, color='blue'):
+                with yaspin(
+                    Spinners.bouncingBar,
+                    text=spinner_text,
+                    color='blue',
+                ):
                     time.sleep(1)
         except KeyboardInterrupt:
             self._logger.debug('Got a KeyboardInterrupt, stopping watcher.')
@@ -210,9 +222,8 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         self._logger.debug(f"Stoped watching {args['in_path']}")
         if self._visual:
             print(
-                colored('Stoped watcher for:', 'blue', attrs=['bold']), colored(
-                    f"{os.path.abspath(args['in_path'])}", 'blue',
-                ),
+                colored('Stoped watcher for:', 'blue', attrs=['bold']),
+                colored(f"{os.path.abspath(args['in_path'])}", 'blue'),
             )
         else:
             self._logger.info(f"Stoped watching {args['in_path']}")
@@ -228,13 +239,13 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         NOTE: This is also default pandoc behaviour
 
         Arguments:
-            in_file {str} -- The absolute path to the file that needs to be
-                             converted
-            out_file {str} -- The absolute path to where the convted file
-                              should be saved
+            in_file {str}  -- The absolute path to the file that needs
+                              to be converted
+            out_file {str} -- The absolute path to where the convted
+                              file should be saved
 
         Returns:
-            None
+            {None}
         """
 
         # Create the pandoc command
@@ -252,17 +263,19 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             for not_allowed in not_allowed_args:
                 if not_allowed in self.pandoc_options['arguments']:
                     self._logger.error(
-                        f'{not_allowed} is allowed as an (extra) pandoc argument.',
+                        f'{not_allowed} is allowed as an (extra) pandoc \
+                        argument.',
                     )
                     raise SystemExit(1)
 
             arguments = self.pandoc_options['arguments']
 
-        pd_command = f'pandoc {in_file} -o {out_file} --template {template} --mathjax {arguments}'
+        pd_command = f'pandoc {in_file} -o {out_file} --template {template} --mathjax {arguments}'  # noqa: E501
 
         self._logger.debug(f'Attempting convertion with command: {pd_command}')
         try:
-            # Stdout and stderr are supressed so that custom information can be shown
+            # Stdout and stderr are supressed so
+            # that custom information can be shown
             subprocess.run(
                 pd_command, shell=True,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -275,15 +288,20 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
     def _convert_dir(self, in_dir_path: str, out_dir_path: str) -> None:
         """Converts all the markdown files in a directory (and subdirectory) to html
 
-        Using pandoc all the files in the `in_dir_path` directory (and it's subdirectories)
-        are converted to html and saved in the out_dir_path and if nessesary in their correct subfolder.
+        Using pandoc all the files in the `in_dir_path` directory
+        (and it's subdirectories) are converted to html and saved
+        in the out_dir_path and if nessesary in their correct subfolder.
+
         So the folder structure and filenames stay the same.
 
-        If the out_dir_path does not exits, it gets created and so do the subdirectories.
+        If the out_dir_path does not exits, it gets created
+        and so do the subdirectories.
 
         Arguments:
-            in_dir_path {str} -- The directory where all the files that need to be converted are located
-            out_dir_path {str} -- The directory where all the converted files will be saved.
+            in_dir_path {str}  -- The directory where all the files that need
+                                  to be converted are located
+            out_dir_path {str} -- The directory where all the converted files
+                                  will be saved.
 
         Returns:
             None
@@ -292,7 +310,8 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
         if self._visual:
             print(
                 colored(
-                    f'Searching for files to convert in {in_dir_path}', 'green',
+                    f'Searching for files to convert in {in_dir_path}',
+                    'green',
                 ),
             )
 
@@ -302,22 +321,26 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
 
         if self._visual:
             print(
-                colored(f'Found ', 'green') + colored(
+                colored('Found ', 'green') + colored(
                     str(len(all_files)),
                     'green', attrs=['bold'],
                 ) + colored(' to convert!', 'green'),
             )
 
         # If in visual mode, a tqdm progress bar will be shown
-        # If not in visual mode it will not be shown so tqdm is replaced with a 'fake' tqdm function
-        # the functions simple returns the first argument it gets, which is the iterable
-        fake_tqdm = lambda x, *args, **kwargs:  x
+        # If not in visual mode it will not be shown so tqdm is replaced with
+        # a 'fake' tqdm function
+
+        # The functions simple returns the first argument it
+        # gets, which is the iterable
+        fake_tqdm = lambda x, *args, **kwargs: x  # noqa: E731
         v_tqdm = tqdm.tqdm if self._visual else fake_tqdm
 
-        # The default logger messes up the tqdm progress bar if visual mode is enabled
-        # Verbose and visual mode can be enabled at the same time, so the logger temporarily
+        # The default logger messes up the tqdm progress bar
+        # if visual mode is enabled
+        # Verbose and visual mode can be enabled at the same time,
+        # so the logger temporarily
         # needs to use tqdm.write
-        # refrence: https://stackoverflow.com/questions/38543506/change-logging-print-function-to-tqdm-write-so-logging-doesnt-interfere-wit
         # FIXME: Actually make it work...
         # class TqdmLogger(logging.Handler):
 
@@ -346,19 +369,29 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             self._logger.info(f'Making new directory: {out_dir_path}')
             os.mkdir(out_dir_path)
 
-        for file_path in v_tqdm(all_files, desc='Converting', ascii=True, colour='green'):
+        for file_path in v_tqdm(
+            all_files,
+            desc='Converting',
+            ascii=True,
+            colour='green',
+        ):
+
             # Get the path of the subdirectory (if anny)
-            # This is done so that the folder structure can be copied over to the output
+            # This is done so that the folder structure can
+            # be copied over to the output
             # Get everything from the filepath after the in_dir_path
             dir_path = file_path[len(os.path.abspath(in_dir_path)):]
             # TODO: Adapt for windows
             # Split by / so there is an array of all the sub directories
             sub_dirs = dir_path.split('/')[1:-1]
-            # Create the subdirectories needed for the current file (if needed)
-            # TODO: Could be (slightly) optimized by checking on forehand if the final directory exists
+            # Create the subdirectories needed for
+            # the current file (if needed)
+            # TODO: Could be (slightly) optimized by checking on
+            # forehand if the final directory exists
             cur_path = out_dir_path
             for d in sub_dirs:
-                # Add the subdirectory path to the current path on each iteration
+                # Add the subdirectory path to the
+                # current path on each iteration
                 cur_path = os.path.join(cur_path, d)
                 if not os.path.isdir(cur_path):
                     self._logger.info(f'Making new (sub)directory: {cur_path}')

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -1,16 +1,16 @@
 import argparse
 import logging
 import sys
-from typing import Optional, Sequence
-
-from termcolor import colored
+from typing import Optional
+from typing import Sequence
 
 from notesystem.modes.base_mode import ModeOptions
-from notesystem.modes.convert_mode import ConvertMode, ConvertModeArguments, PandocOptions
-from notesystem.modes.check_mode.check_mode import CheckMode, ALL_ERRORS
-
-
+from notesystem.modes.check_mode.check_mode import ALL_ERRORS
+from notesystem.modes.check_mode.check_mode import CheckMode
+from notesystem.modes.convert_mode import ConvertMode
+from notesystem.modes.convert_mode import PandocOptions
 # TODO: Move the creating of sub parsers to the mode
+
 
 def create_argparser() -> argparse.ArgumentParser:
     """Parse the command line arguments
@@ -66,20 +66,23 @@ def create_argparser() -> argparse.ArgumentParser:
     convert_parser.add_argument(
         '--watch',
         '-w',
-        help='enables watch mode (convert files that have changed as soon as they have changed)',
+        help='enables watch mode (convert files that have changed \
+              as soon as they have changed)',
         action='store_true',
         default=False,
     )
 
     convert_parser.add_argument(
         '--pandoc-args',
-        help="specify the arguments that need to based on to pandoc. E.g.: --pandoc-args='--standalone --preserve-tabs'",
+        help="specify the arguments that need to based on to pandoc. \
+              E.g.: --pandoc-args='--standalone --preserve-tabs'",
         metavar='ARGS',
     )
 
     convert_parser.add_argument(
         '--pandoc-template',
-        help='Specify a template for pandoc to use in convertion. Default: GitHub.html5',
+        help='Specify a template for pandoc to use in convertion. \
+             Default: GitHub.html5',
         metavar='T',
     )
 
@@ -108,7 +111,8 @@ def create_argparser() -> argparse.ArgumentParser:
 
     # Disable certain errors
     disable_errors_group = check_parser.add_argument_group(
-        'Disable error types', 'Using these flags you can disable checking for certain errors',
+        'Disable error types',
+        'Using these flags you can disable checking for certain errors',
     )
 
     for error in ALL_ERRORS:

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -6,7 +6,7 @@ from typing import Optional, Sequence
 from termcolor import colored
 
 from notesystem.modes.base_mode import ModeOptions
-from notesystem.modes.convert_mode import ConvertMode, ConvertModeArguments
+from notesystem.modes.convert_mode import ConvertMode, ConvertModeArguments, PandocOptions
 from notesystem.modes.check_mode.check_mode import CheckMode
 
 
@@ -78,6 +78,12 @@ def create_argparser() -> argparse.ArgumentParser:
         metavar='ARGS',
     )
 
+    convert_parser.add_argument(
+        '--pandoc-template',
+        help='Specify a template for pandoc to use in convertion. Default: GitHub.html5',
+        metavar='T',
+    )
+
     # Check parser
     # Used for the checking mode
     check_parser = mode_parser.add_parser(
@@ -142,13 +148,17 @@ def main(argv: Optional[Sequence[str]] = None):
         }
         check_mode.start(mode_options)
     elif args['mode'] == 'convert':
+        pandoc_options: PandocOptions = {
+            'arguments': args['pandoc_args'],
+            'template': args['pandoc_template'],
+        }
         convert_mode_options: ModeOptions = {
             'visual': True,
             'args': {
                 'in_path': args['in_path'],
                 'out_path': args['out_path'],
                 'watch': args['watch'],
-                'pandoc_args': args['pandoc_args'],
+                'pandoc_options': pandoc_options,
             },
         }
         convert_mode.start(convert_mode_options)

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -162,7 +162,6 @@ def main(argv: Optional[Sequence[str]] = None):
             if arg_name.startswith('d'):
                 if args[arg_name] == True:
                     disabled_errors.append(arg_name[2:])
-
         mode_options: ModeOptions = {
             'visual': True,
             'args': {

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name='notesystem',

--- a/tests/cli/base_mode_test.py
+++ b/tests/cli/base_mode_test.py
@@ -1,11 +1,12 @@
 """Test the default behaviour of the base mode"""
 import pytest
-from notesystem.modes.base_mode import BaseMode
 
+from notesystem.modes.base_mode import BaseMode
 
 # def test_base_mode_has_logger():
 #     base_mode = BaseMode()
 #     assert base_mode._logger is not None
+
 
 def test_base_mode_default_behaviour():
     base_mode = BaseMode()

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -25,6 +25,7 @@ def test_check_mode_called_with_only_in_path(mock_check_mode_start: Mock):
     expected_args: CheckModeArgs = {
         'in_path': 'tests/test_documents',
         'fix': False,
+        'disabled_errors': [],
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -43,6 +44,7 @@ def test_check_mode_called_with_in_path_and_fix(mock_check_mode_start: Mock):
     expected_args: CheckModeArgs = {
         'in_path': 'tests/test_documents',
         'fix': True,
+        'disabled_errors': [],
     }
     expected_options: ModeOptions = {
         'visual': True,

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -6,6 +6,8 @@ import pytest
 from notesystem.modes.base_mode import ModeOptions
 from notesystem.modes.check_mode.check_mode import CheckMode
 from notesystem.modes.check_mode.check_mode import CheckModeArgs
+from notesystem.modes.check_mode.errors.markdown_errors import MathError
+from notesystem.modes.check_mode.errors.markdown_errors import TodoError
 from notesystem.notesystem import main
 
 
@@ -172,3 +174,54 @@ def test_check_mode_fix_file(tmpdir, wrong, good):
     check_mode._fix_doc_errors(errors)
     c1 = file.read()
     assert c1 == good
+
+# Test disabling errors
+
+# Skip by passsing flag
+
+
+@patch('notesystem.modes.check_mode.check_mode.CheckMode.start')
+def test_check_mode_disable_errors_with_one_flag(mock_check_mode_start: Mock):
+
+    main([
+        'check',
+        'tests/test_documents/contains_errors.md',
+        '--disable-todo',
+    ])
+
+    expected_args: CheckModeArgs = {
+        'in_path': 'tests/test_documents/contains_errors.md',
+        'fix': False,
+        'disabled_errors': [TodoError.get_error_name()],
+    }
+    expected_options: ModeOptions = {
+        'visual': True,
+        'args': expected_args,  # type: ignore
+    }
+    mock_check_mode_start.assert_called_once_with(expected_options)
+
+
+@patch('notesystem.modes.check_mode.check_mode.CheckMode.start')
+def test_check_mode_disable_errors_with_multiple_flags(
+        mock_check_mode_start: Mock,
+):
+
+    main([
+        'check', 'tests/test_documents/contains_errors.md',
+        '--disable-todo', '--disable-math-error',
+    ])
+    expected_args: CheckModeArgs = {
+        'in_path': 'tests/test_documents/contains_errors.md',
+        'fix': False,
+        'disabled_errors': [
+            MathError.get_error_name(),
+            TodoError.get_error_name(),
+        ],
+    }
+    expected_options: ModeOptions = {
+        'visual': True,
+        'args': expected_args,  # type: ignore
+    }
+    mock_check_mode_start.assert_called_once_with(expected_options)
+
+# Pass by setting it manually

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -1,11 +1,12 @@
-import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
-from notesystem.notesystem import main
 from notesystem.modes.base_mode import ModeOptions
-from notesystem.modes.check_mode.check_mode import CheckModeArgs, CheckMode
+from notesystem.modes.check_mode.check_mode import CheckMode
+from notesystem.modes.check_mode.check_mode import CheckModeArgs
+from notesystem.notesystem import main
 
 
 def test_required_arguments():
@@ -17,7 +18,9 @@ def test_required_arguments():
 
 @patch('notesystem.modes.check_mode.check_mode.CheckMode.start')
 def test_check_mode_called_with_only_in_path(mock_check_mode_start: Mock):
-    """Tests that the correct arguments are passed to check mode with only a input path"""
+    """Tests that the correct arguments are passed
+       to check mode with only a input path
+    """
     main(['check', 'tests/test_documents'])
     expected_args: CheckModeArgs = {
         'in_path': 'tests/test_documents',
@@ -33,7 +36,9 @@ def test_check_mode_called_with_only_in_path(mock_check_mode_start: Mock):
 
 @patch('notesystem.modes.check_mode.check_mode.CheckMode.start')
 def test_check_mode_called_with_in_path_and_fix(mock_check_mode_start: Mock):
-    """Tests that the correct arguments are passed to check mode with  a input path and fixing enabled"""
+    """Tests that the correct arguments are passed to check mode with
+       a input path and fixing enabled
+    """
     main(['check', 'tests/test_documents', '-f'])
     expected_args: CheckModeArgs = {
         'in_path': 'tests/test_documents',
@@ -59,9 +64,13 @@ def test_check_mode_checks_dir_when_given_dir(mock: Mock):
 
 @patch('notesystem.modes.check_mode.check_mode.CheckMode._check_dir')
 @patch('notesystem.modes.check_mode.check_mode.CheckMode._check_file')
-def test_check_mode_checks_file_when_given_file(_check_file: Mock, _check_dir: Mock):
+def test_check_mode_checks_file_when_given_file(
+    _check_file: Mock,
+    _check_dir: Mock,
+):
     """Test that when given a filepath only _check_file is called"""
-    # Some parts need access to the terminal, but they don'y have access so they raise value error
+    # Some parts need access to the terminal,
+    # but they don'y have access so they raise value error
     # Which can be ignored
     try:
         main(['check', 'tests/test_documents/ast_error_test_1.md'])
@@ -104,7 +113,8 @@ def test_check_mode_check_dir_raises_with_file_and_not_existing_dir():
 
 
 def test_check_mode_check_dir_returns():
-    """Test that check_mode dirs returns as much doc errors as are present in the folder
+    """Test that check_mode dirs returns as much doc errors as are
+       present in the folder
 
     TODO: Make test independent of test/test_documents file amount
 
@@ -115,7 +125,9 @@ def test_check_mode_check_dir_returns():
 
 
 def test_check_mode_check_file_returns():
-    """Test that _check_file checks the file and returns errors and the correct filepath"""
+    """Test that _check_file checks the file and returns
+       errors and the correct filepath
+    """
     check_mode = CheckMode()
     errors = check_mode._check_file('tests/test_documents/contains_errors.md')
     assert errors['errors'] is not None

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -96,8 +96,8 @@ def test_fix_is_called_when_fix_arg_is_passed(_fix_doc_errors: Mock):
 
 
 def test_check_mode_raises_with_non_existing_dir_or_file():
-    """Test that when a invalid path is given FileNotFoundError is raised"""
-    with pytest.raises(FileNotFoundError):
+    """Test that when a invalid path is given SystemExit is raised"""
+    with pytest.raises(SystemExit):
         main(['check', 'no dir'])
 
 

--- a/tests/cli/check_mode_test.py
+++ b/tests/cli/check_mode_test.py
@@ -122,6 +122,9 @@ def test_check_mode_check_dir_returns():
 
     """
     check_mode = CheckMode()
+    # Set the _disabled_errros manually, because  it is set in start()
+    # which is not run in this test
+    check_mode._disabled_errors = []
     errors = check_mode._check_dir('tests/test_documents')
     assert len(errors) == 3
 
@@ -131,6 +134,7 @@ def test_check_mode_check_file_returns():
        errors and the correct filepath
     """
     check_mode = CheckMode()
+    check_mode._disabled_errors = []
     errors = check_mode._check_file('tests/test_documents/contains_errors.md')
     assert errors['errors'] is not None
     assert errors['file_path'] == 'tests/test_documents/contains_errors.md'
@@ -163,6 +167,7 @@ def test_check_mode_fix_file(tmpdir, wrong, good):
     file = tmpdir.join('test.md')
     file.write(wrong)
     check_mode = CheckMode()
+    check_mode._disabled_errors = []
     errors = check_mode._check_file(file.strpath)
     check_mode._fix_doc_errors(errors)
     c1 = file.read()

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -146,30 +146,23 @@ def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
     )
 
 
-# @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Github Actions does not play well with tmpdirs')
-# def test_convert_file_converts_file(tmpdir: py.path.local):
-#     """Test that convert file convert the file correctly using pandoc with default GitHub.html5 template"""
-#     content = """\
-# # Heading 1
+@pytest.mark.parametrize(
+    'not_allowed_arg', [
+        '-o',
+        '--to',
+        '--from',
+        '--mathjax'
+        '--template',
+    ],
+)
+def test_convert_file_raises_with_not_allowed_pandoc_args(not_allowed_arg):
+    """Test that when there are not allowed arguments given as --pandoc-args pararameters _convert_file raises SystemExit(1) error"""
 
-# Paragrpah text
-#         """
-#     file = tmpdir.join('test.md')
-#     out_file = tmpdir.join('test.html')
-#     pandoc_out = tmpdir.join('pd.html')
-#     file.write(content)
-
-#     print(f"OSSS::::::: {os.environ.get('CI')}")
-#     conv_mode = ConvertMode()
-#     conv_mode._convert_file(file.strpath, out_file.strpath)
-
-#     pd_command = f'pandoc {file.strpath} -o {pandoc_out.strpath} --template GitHub.html5 --mathjax'
-#     subprocess.run(
-#         pd_command, shell=True,
-#         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-#     )
-
-#     assert out_file.read() == pandoc_out.read()
+    with pytest.raises(SystemExit):
+        main([
+            'convert', 'tests/test_documents/contains_errors.md',
+            'output.html', f'--pandoc-args={not_allowed_arg}',
+        ])
 
 
 def test_handle_subprocess_error(capsys: pytest.CaptureFixture):

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -27,7 +27,10 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': False,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -64,7 +67,10 @@ def test_convert_mode_gets_correct_args_with_w_flag(mock_start: Mock):
         'in_path': 'tests/test_documents',
         'out_path': 'tests/out',
         'watch': True,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     expected_options: ModeOptions = {
         'visual': True,
@@ -87,13 +93,12 @@ def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
     # NOTE: No files should be written to test_out/ folder because convert_dir is mocked
     main(['convert', 'tests/test_documents/contains_errors.md', 'test_out.html'])
     convert_file_mock.assert_called_with(
-        # Note: None is for pandoc_args
-        'tests/test_documents/contains_errors.md', 'test_out.html', None,
+        'tests/test_documents/contains_errors.md', 'test_out.html',
     )
 
 
 @patch('subprocess.run')
-def test_pandoc_command_with_correct_args(run_mock: Mock):
+def test_pandoc_command_with_correct_args_options(run_mock: Mock):
     """Test that pandoc is called with the correct filenames and flags"""
 
     in_file = 'tests/test_documents/ast_error_test_1.md'
@@ -105,6 +110,41 @@ def test_pandoc_command_with_correct_args(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
+
+
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_args_template(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags"""
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.html'
+    pd_template = 'easy_template.html'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax '
+
+    main(['convert', in_file, out_file, f'--pandoc-template={pd_template}'])
+    run_mock.assert_called_once_with(
+        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags when a custom template is used and extra arguments are given"""
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.html'
+    pd_template = 'easy_template.html'
+    pd_args = '--preserve-tabs --standalone'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args}'
+
+    main([
+        'convert', in_file, out_file,
+        f'--pandoc-template={pd_template}', f'--pandoc-args={pd_args}',
+    ])
+    run_mock.assert_called_once_with(
+        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
 
 # @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Github Actions does not play well with tmpdirs')
 # def test_convert_file_converts_file(tmpdir: py.path.local):
@@ -157,7 +197,10 @@ def test_watcher_is_called_when_watch_mode(start_watch_mode_mock: Mock, _):
         'in_path': 'tests/test_documents/contains_errors.md',
         'out_path': 'test_out.html',
         'watch': True,
-        'pandoc_args': None,
+        'pandoc_options': {
+            'template': None,
+            'arguments': None,
+        },
     }
     start_watch_mode_mock.assert_called_once_with(expected_args)
 

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -1,14 +1,13 @@
-import os
-import shutil
 import subprocess
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
-import py
 
-from notesystem.notesystem import main
 from notesystem.modes.base_mode import ModeOptions
-from notesystem.notesystem import ConvertMode, ConvertModeArguments
+from notesystem.modes.convert_mode import ConvertModeArguments
+from notesystem.notesystem import main
 
 
 def test_convert_mode_required_argds():
@@ -41,7 +40,9 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
 
 @patch('shutil.which')
 def test_convert_mode_checks_pandoc_install(mock_which: Mock):
-    """Check that shutil.which is called to check if pandoc is installed when convert mode is started"""
+    """Check that shutil.which is called to check if pandoc is installed
+        when convert mode is started
+    """
     # Test that error is raised when pandoc is not installed
     mock_which.return_value = None
     with pytest.raises(SystemExit):
@@ -81,8 +82,11 @@ def test_convert_mode_gets_correct_args_with_w_flag(mock_start: Mock):
 
 @patch('notesystem.modes.convert_mode.ConvertMode._convert_dir')
 def test_convert_dir_is_called_when_in_path_is_dir(convert_dir_mock: Mock):
-    """Test that _convert_dir is called when the given input path is a folder"""
-    # NOTE: No files should be written to test_out/ folder because convert_dir is mocked
+    """Test that _convert_dir is called when the given
+       input path is a folder
+    """
+    # NOTE: No files should be written to test_out/ folder
+    # because convert_dir is mocked
     main(['convert', 'tests/test_documents', 'test_out'])
     convert_dir_mock.assert_called_with('tests/test_documents', 'test_out')
 
@@ -90,8 +94,12 @@ def test_convert_dir_is_called_when_in_path_is_dir(convert_dir_mock: Mock):
 @patch('notesystem.modes.convert_mode.ConvertMode._convert_file')
 def test_convert_file_is_called_when_in_path_is_file(convert_file_mock: Mock):
     """Test that _convert_file is called when the given input path is a file"""
-    # NOTE: No files should be written to test_out/ folder because convert_dir is mocked
-    main(['convert', 'tests/test_documents/contains_errors.md', 'test_out.html'])
+
+    main([
+        'convert',
+        'tests/test_documents/contains_errors.md',
+        'test_out.html',
+    ])
     convert_file_mock.assert_called_with(
         'tests/test_documents/contains_errors.md', 'test_out.html',
     )
@@ -104,11 +112,15 @@ def test_pandoc_command_with_correct_args_options(run_mock: Mock):
     in_file = 'tests/test_documents/ast_error_test_1.md'
     out_file = 'test/test_documents/out.html'
     pd_args = '--preserve-tabs --standalone'
-    pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args}'
+    pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args}'  # noqa: E501
 
     main(['convert', in_file, out_file, f'--pandoc-args={pd_args}'])
+
     run_mock.assert_called_once_with(
-        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 
@@ -119,30 +131,38 @@ def test_pandoc_command_with_correct_args_template(run_mock: Mock):
     in_file = 'tests/test_documents/ast_error_test_1.md'
     out_file = 'test/test_documents/out.html'
     pd_template = 'easy_template.html'
-    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax '
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax '  # noqa: E501
 
     main(['convert', in_file, out_file, f'--pandoc-template={pd_template}'])
     run_mock.assert_called_once_with(
-        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 
 @patch('subprocess.run')
 def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
-    """Test that pandoc is called with the correct filenames and flags when a custom template is used and extra arguments are given"""
+    """Test that pandoc is called with the correct filenames and
+       flags when a custom template is used and extra arguments are given
+    """
 
     in_file = 'tests/test_documents/ast_error_test_1.md'
     out_file = 'test/test_documents/out.html'
     pd_template = 'easy_template.html'
     pd_args = '--preserve-tabs --standalone'
-    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args}'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args}'  # noqa: E501
 
     main([
         'convert', in_file, out_file,
         f'--pandoc-template={pd_template}', f'--pandoc-args={pd_args}',
     ])
     run_mock.assert_called_once_with(
-        pd_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 
@@ -156,7 +176,9 @@ def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
     ],
 )
 def test_convert_file_raises_with_not_allowed_pandoc_args(not_allowed_arg):
-    """Test that when there are not allowed arguments given as --pandoc-args pararameters _convert_file raises SystemExit(1) error"""
+    """Test that when there are not allowed arguments given
+       as --pandoc-args pararameters _convert_file raises SystemExit(1) error
+    """
 
     with pytest.raises(SystemExit):
         main([
@@ -165,27 +187,41 @@ def test_convert_file_raises_with_not_allowed_pandoc_args(not_allowed_arg):
         ])
 
 
-def test_handle_subprocess_error(capsys: pytest.CaptureFixture):
+def test_handle_subprocess_error():
     """Test that subprocess.CalledProcessError is handled and program quits"""
     mock = MagicMock(side_effect=subprocess.CalledProcessError(1, cmd='Test'))
     with patch('subprocess.run', mock) as run_mock:
         with pytest.raises(SystemExit):
-            main(['convert', 'tests/test_documents/contains_errors.md', 'out.html'])
+            main([
+                'convert',
+                'tests/test_documents/contains_errors.md',
+                'out.html',
+            ])
             run_mock.assert_called()
 
 
 def test_file_not_found_error_raised_with_invalid_path():
     """Test that FileNotFoundError is raised when a invalid path is given"""
     with pytest.raises(FileNotFoundError):
-        main(['convert', 'tests/test_documents/doesnotexist.md', 'test_out.html'])
+        main([
+            'convert',
+            'tests/test_documents/doesnotexist.md',
+            'test_out.html',
+        ])
 
 
-# _convert_file is mocked here, so that no actual convertion happens and watch mode is still called
+# _convert_file is mocked here
+# so that no actual convertion happens and watch mode is still called
 @patch('notesystem.modes.convert_mode.ConvertMode._convert_file')
 @patch('notesystem.modes.convert_mode.ConvertMode._start_watch_mode')
 def test_watcher_is_called_when_watch_mode(start_watch_mode_mock: Mock, _):
     """Test that _start_watch_mode_is_called"""
-    main(['convert', 'tests/test_documents/contains_errors.md', 'test_out.html', '-w'])
+    main([
+        'convert',
+        'tests/test_documents/contains_errors.md',
+        'test_out.html',
+        '-w',
+    ])
     expected_args: ConvertModeArguments = {
         'in_path': 'tests/test_documents/contains_errors.md',
         'out_path': 'test_out.html',

--- a/tests/common/utils_test.py
+++ b/tests/common/utils_test.py
@@ -1,8 +1,5 @@
-import os
-from typing import List
-
-import pytest
 import py
+import pytest
 
 from notesystem.common.utils import find_all_md_files
 
@@ -29,4 +26,4 @@ def test_find_all_md_files_only_returns_md_files(tmpdir: py.path.local):
 
 def test_find_all_md_files_raises_when_dir_does_not_exist():
     with pytest.raises(NotADirectoryError):
-        files = find_all_md_files('nodir')
+        _ = find_all_md_files('nodir')

--- a/tests/errors/check_mode_ast_errors_test.py
+++ b/tests/errors/check_mode_ast_errors_test.py
@@ -1,6 +1,7 @@
 import pytest
 
-from notesystem.modes.check_mode.errors.ast_errors import *
+from notesystem.modes.check_mode.errors.ast_errors import AstError
+from notesystem.modes.check_mode.errors.ast_errors import ListIndentError
 
 ##################################
 # --- TEST LIST INDENT ERROR --- #

--- a/tests/errors/check_mode_markdown_errors_test.py
+++ b/tests/errors/check_mode_markdown_errors_test.py
@@ -3,7 +3,10 @@ from typing import List
 
 import pytest
 
-from notesystem.modes.check_mode.errors.markdown_errors import *
+from notesystem.modes.check_mode.errors.markdown_errors import MarkdownError
+from notesystem.modes.check_mode.errors.markdown_errors import MathError
+from notesystem.modes.check_mode.errors.markdown_errors import SeperatorError
+from notesystem.modes.check_mode.errors.markdown_errors import TodoError
 
 ################################
 # --- TEST BASE ERROR --- #
@@ -38,7 +41,7 @@ def test_seperator_error_validate(test_input: List[str], expected: bool):
 @pytest.mark.parametrize(
     'test_input,expected', [
         ('---\n', '---\n\n'),
-        ('-'*9 + '\n', '-'*9 + '\n\n'),
+        ('-' * 9 + '\n', '-' * 9 + '\n\n'),
     ],
 )
 def test_seperator_error_fix(test_input: str, expected: str):


### PR DESCRIPTION
Using command line flags certain errors can no be disabled. 

```
Disable error types:
  Using these flags you can disable checking for certain errors

  --disable-math-error  Disable: Math Error (`$$` used)
  --disable-todo-error  Disable: Todo Error (no `-` used in todo item)
  --disable-seperator-error
                        Disable: Seperator Error (`---` used without new line)
  --disable-list-indent-error
                        Disable: List Indent Error (list is not properly
                        indented)

```