### PR TITLE
Convert to pdf option.

### DIFF
--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -44,7 +44,8 @@ def create_argparser() -> argparse.ArgumentParser:
     # Used for the convert mode,
     convert_parser = mode_parser.add_parser(
         'convert',
-        help='convert files from markdown to html',
+        help='convert files from markdown to html (by default) or to pdf \
+             (using --to-pdf)',
     )
     # Set a default, so later on it is clear whith mode is used
     convert_parser.set_defaults(mode='convert')
@@ -81,9 +82,16 @@ def create_argparser() -> argparse.ArgumentParser:
 
     convert_parser.add_argument(
         '--pandoc-template',
-        help='Specify a template for pandoc to use in convertion. \
-             Default: GitHub.html5',
+        help='specify a template for pandoc to use in convertion. \
+              Default: GitHub.html5 (for md to html)',
         metavar='T',
+    )
+
+    convert_parser.add_argument(
+        '--to-pdf',
+        help='convert the markdown files to pdf instead of html. \
+              Note: No template is used by default.',
+        action='store_true',
     )
 
     # Check parser
@@ -176,6 +184,10 @@ def main(argv: Optional[Sequence[str]] = None):
         pandoc_options: PandocOptions = {
             'arguments': args['pandoc_args'],
             'template': args['pandoc_template'],
+            # NOTE: When adding more output options (perhaps) in the future
+            # this should probably become an enum and there should be
+            # an check that not multiple --to-... arguments are passed
+            'output_format': 'html' if not args['to_pdf'] else 'pdf',
         }
         convert_mode_options: ModeOptions = {
             'visual': True,

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -145,6 +145,69 @@ def test_pandoc_command_with_correct_args_template(run_mock: Mock):
 
 
 @patch('subprocess.run')
+def test_pandoc_command_with_correct_file_output(run_mock: Mock):
+    """Test that pandoc is called with the -t pdf when --to-pdf
+       is specified.
+    """
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.pdf'
+    pd_command = f'pandoc {in_file} -o {out_file}  --mathjax  -t pdf'  # noqa: E501
+
+    main(['convert', in_file, out_file, '--to-pdf'])
+    run_mock.assert_called_once_with(
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@patch('subprocess.run')
+def test_pandoc_command_with_correct_file_output_with_template(run_mock: Mock):
+    """Test that pandoc is called with the correct filenames and flags when
+       --to-pdf is passed and also a template is specified.
+    """
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    out_file = 'test/test_documents/out.pdf'
+    pd_template = 'eisvogel.latex'
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax  -t pdf'  # noqa: E501
+
+    main([
+        'convert', in_file, out_file,
+        f'--pandoc-template={pd_template}', '--to-pdf',
+    ])
+    run_mock.assert_called_once_with(
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@patch('subprocess.run')
+def test_pandoc_command_with_changed_to_pdf_with_html_filename(run_mock: Mock):
+    """ Test that the output file name extension is changed to
+        .pdf when .html is given
+    """
+
+    in_file = 'tests/test_documents/ast_error_test_1.md'
+    # Outfile is html file but should be .pdf beause --to-pdf passed
+    out_file = 'test/test_documents/out.html'
+    out_file_correct = 'test/test_documents/out.pdf'
+    pd_command = f'pandoc {in_file} -o {out_file_correct}  --mathjax  -t pdf'  # noqa: E501
+
+    main(['convert', in_file, out_file, '--to-pdf'])
+    run_mock.assert_called_once_with(
+        pd_command,
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@patch('subprocess.run')
 def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
     """Test that pandoc is called with the correct filenames and
        flags when a custom template is used and extra arguments are given

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -29,6 +29,7 @@ def test_convert_mode_called_correct_args(mock_convert_mode: Mock):
         'pandoc_options': {
             'template': None,
             'arguments': None,
+            'output_format': 'html',
         },
     }
     expected_options: ModeOptions = {
@@ -71,6 +72,7 @@ def test_convert_mode_gets_correct_args_with_w_flag(mock_start: Mock):
         'pandoc_options': {
             'template': None,
             'arguments': None,
+            'output_format': 'html',
         },
     }
     expected_options: ModeOptions = {
@@ -112,7 +114,7 @@ def test_pandoc_command_with_correct_args_options(run_mock: Mock):
     in_file = 'tests/test_documents/ast_error_test_1.md'
     out_file = 'test/test_documents/out.html'
     pd_args = '--preserve-tabs --standalone'
-    pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args}'  # noqa: E501
+    pd_command = f'pandoc {in_file} -o {out_file} --template GitHub.html5 --mathjax {pd_args} -t html'  # noqa: E501
 
     main(['convert', in_file, out_file, f'--pandoc-args={pd_args}'])
 
@@ -131,7 +133,7 @@ def test_pandoc_command_with_correct_args_template(run_mock: Mock):
     in_file = 'tests/test_documents/ast_error_test_1.md'
     out_file = 'test/test_documents/out.html'
     pd_template = 'easy_template.html'
-    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax '  # noqa: E501
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax  -t html'  # noqa: E501
 
     main(['convert', in_file, out_file, f'--pandoc-template={pd_template}'])
     run_mock.assert_called_once_with(
@@ -152,7 +154,7 @@ def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
     out_file = 'test/test_documents/out.html'
     pd_template = 'easy_template.html'
     pd_args = '--preserve-tabs --standalone'
-    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args}'  # noqa: E501
+    pd_command = f'pandoc {in_file} -o {out_file} --template {pd_template} --mathjax {pd_args} -t html'  # noqa: E501
 
     main([
         'convert', in_file, out_file,
@@ -229,6 +231,7 @@ def test_watcher_is_called_when_watch_mode(start_watch_mode_mock: Mock, _):
         'pandoc_options': {
             'template': None,
             'arguments': None,
+            'output_format': 'html',
         },
     }
     start_watch_mode_mock.assert_called_once_with(expected_args)


### PR DESCRIPTION
Using the `--to-pdf` flag you now can convert to pdf files instead of html files.

Closes: #32.

