### PR TITLE
Show pandoc errors and warnings.

### DIFF
--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -399,7 +399,8 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
             # Stdout and stderr are supressed so
             # that custom information can be shown
             result = subprocess.run(
-                pd_command, shell=True,
+                pd_command,
+                shell=True,
                 capture_output=True,
             )
 

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -432,9 +432,11 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
                             ),
                         )
                     else:
+                        # TODO: Print could not convert error message
+                        #       Next to the pandoc error message
                         print_correct(
                             colored(
-                                'PANDOC WARNING:',
+                                'PANDOC ERROR:',
                                 'red', attrs=['bold'],
                             ),
                         )

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -436,6 +436,13 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
                         #       Next to the pandoc error message
                         print_correct(
                             colored(
+                                f'Could not convert {in_file} into {out_file}. See error message below.',  # noqa: E501
+                                'red',
+                                attrs=['bold'],
+                            ),
+                        )
+                        print_correct(
+                            colored(
                                 'PANDOC ERROR:',
                                 'red', attrs=['bold'],
                             ),

--- a/notesystem/modes/convert_mode.py
+++ b/notesystem/modes/convert_mode.py
@@ -30,6 +30,8 @@ class PandocOptions(TypedDict):
     template: Optional[str]
     # The output format (for now 'html' or 'pdf')
     output_format: str
+    # Wether to ignore warnings thrown by pandoc
+    ignore_warnings: bool
 
 
 class ConvertModeArguments(TypedDict):
@@ -418,22 +420,21 @@ class ConvertMode(BaseMode[ConvertModeArguments]):
                             print(x)
 
                     if error_text.startswith('[WARNING]'):
-                        print_correct(
-                            colored(
-                                'PANDOC WARNING:',
-                                'yellow', attrs=['bold'],
-                            ),
-                        )
-                        print_correct(
-                            colored(
-                                result.stderr.decode(
-                                    'utf-8',
-                                ).strip(), 'yellow',
-                            ),
-                        )
+                        if not self._pandoc_options['ignore_warnings']:
+                            print_correct(
+                                colored(
+                                    'PANDOC WARNING:',
+                                    'yellow', attrs=['bold'],
+                                ),
+                            )
+                            print_correct(
+                                colored(
+                                    result.stderr.decode(
+                                        'utf-8',
+                                    ).strip(), 'yellow',
+                                ),
+                            )
                     else:
-                        # TODO: Print could not convert error message
-                        #       Next to the pandoc error message
                         print_correct(
                             colored(
                                 f'Could not convert {in_file} into {out_file}. See error message below.',  # noqa: E501

--- a/notesystem/notesystem.py
+++ b/notesystem/notesystem.py
@@ -93,6 +93,11 @@ def create_argparser() -> argparse.ArgumentParser:
               Note: No template is used by default.',
         action='store_true',
     )
+    convert_parser.add_argument(
+        '--ignore-warnings',
+        help='ignore warnings from pandoc',
+        action='store_true',
+    )
 
     # Check parser
     # Used for the checking mode
@@ -188,6 +193,7 @@ def main(argv: Optional[Sequence[str]] = None):
             # this should probably become an enum and there should be
             # an check that not multiple --to-... arguments are passed
             'output_format': 'html' if not args['to_pdf'] else 'pdf',
+            'ignore_warnings': args['ignore_warnings'],
         }
         convert_mode_options: ModeOptions = {
             'visual': True,

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -324,10 +324,13 @@ def test_pandoc_warnings_are_printed(capsys, tmpdir: Path):
 
     main([
         'convert',
-        # Next to the fact that it contains errors, it also has
-        # no title, which means that pandoc will throw a warning
         'tests/test_documents/contains_errors.md',
         str(outfile_path),
+        # Standalone raises an warning
+        '--pandoc-args="--standalone"',
+        # Default template not installed in CI.
+        # Therefor not using a template (because throws error)
+        f'--pandoc-template={""}',
     ])
 
     captured = capsys.readouterr()
@@ -350,6 +353,11 @@ def test_pandoc_warnings_are_not_printed_with_ignore_warnings_flag(
         # no title, which means that pandoc will throw a warning
         'tests/test_documents/contains_errors.md',
         str(outfile_path),
+        # Standalone raises an warning
+        '--pandoc-args="--standalone"',
+        # Default template not installed in CI.
+        # Therefor not using a template (because throws error)
+        f'--pandoc-template={""}',
         '--ignore-warnings',
     ])
 

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -333,6 +333,7 @@ def test_pandoc_errors_are_printed(capsys, tmpdir: Path):
 
     captured = capsys.readouterr()
     assert 'PANDOC ERROR' in captured.out
+    assert 'Could not convert' in captured.out
 
 
 # Check that custom watcher is used

--- a/tests/cli/convert_mode_test.py
+++ b/tests/cli/convert_mode_test.py
@@ -121,8 +121,7 @@ def test_pandoc_command_with_correct_args_options(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 
@@ -139,8 +138,7 @@ def test_pandoc_command_with_correct_args_template(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 
@@ -158,8 +156,7 @@ def test_pandoc_command_with_correct_file_output(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 
@@ -181,8 +178,7 @@ def test_pandoc_command_with_correct_file_output_with_template(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 
@@ -202,8 +198,7 @@ def test_pandoc_command_with_changed_to_pdf_with_html_filename(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 
@@ -226,8 +221,7 @@ def test_pandoc_command_with_correct_args_template_and_options(run_mock: Mock):
     run_mock.assert_called_once_with(
         pd_command,
         shell=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
 
 


### PR DESCRIPTION
When pandoc finds a problem in the file is has to convert if throws an error/warnings. These are usefull for to see. Therefore printing them makes sense.

You can disable printing warnings with the `--ignore-warnings` flag. 
Printing errors cannot be disabled because when an error occurs the file is not converted, which is 'crucial' information.

Closes: #36 